### PR TITLE
restructure, update and pin python version in the env file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,116 +2,178 @@ name: coclico
 channels:
   - conda-forge
   - defaults
+
 dependencies:
-  - python=3.*
+  # Basic tools
+  - python=3.12
   - pip>=20
+  - setuptools
+  - conda-libmamba-solver
+  - ca-certificates
+  - certifi
+  - openssl
+  - boltons
+  - ciso8601
+  - cattrs
+
+# Development Tools
+  - bandit
+  - black
+  - click
+  - codespell
+  - flake8
+  - isort
+  - mypy
+  - nbsphinx
+  - poetry
+  - pre-commit
+  - pydantic
+  - pytest
+  - pytest-cov
+  - recommonmark
+  - ruff
+  - sphinx
+  - sphinx-autodoc-typehints
+  - sphinx-rtd-theme
+  - sphinx_rtd_theme
+  - python-dotenv
+
+  # Jupyter and extensions
+  - ipython
   - ipykernel
   - ipywidgets
+  - jupyter
+  - jupyterlab>=4
+  - jupyter-panel-proxy
+  - jupyter-resource-usage
+  - jupyterlab_code_formatter
+  - jupyterlab_execute_time
+  - jupyterlab_widgets
+  - jupyterlab-git
+  - jupyterlab-lsp
+  - jupyterlab-spellchecker
+  - nb_conda_kernels
+  - nbgitpuller
+  - nbstripout
+  - nodejs
+  - python-lsp-server
+  - voila
+  - jupyter-book
+  - nbformat
+  - dask-labextension
+  # - gh-scoped-creds # check if useful
+  # - lckr-jupyterlab-variableinspector  # doesn't work on my machine yet
+
+  # Interactive visualization libraries
+  - bokeh
+  - datashader
+  - firefox
+  - folium
+  - geckodriver
+  - geoviews
+  - holoviews
+  - hvplot
   - ipyleaflet
+  - ipympl
+  - jupyter_bokeh
+  - panel
+  - param
+  - selenium
+
+  # Standard sci-data analytics libs
+  - bottleneck
+  - cchardet
+  - numexpr
+  - fsspec
+  - intake
+  - jsonschema
+  - netcdf4
+  - numcodecs
+  - numpy
+  - opencv
+  - pandas
+  - pint
+  - polars
+  - pyarrow
+  - pyproj
+  - pyyaml
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - toml
+  - xarray
+
+  # Cloud-related libraries
   - adlfs
-  - astropy
   - awscli
   - azure-data-tables
   - azure-identity
-  - bandit
-  - beautifulsoup4
-  - black
-  - boltons
   - boto3
+  - gcsfs
+  - google-cloud-storage
+  - s3fs
+
+  # Plotting libraries
+  - descartes
+  - matplotlib
+  - pillow
+  - seaborn
+
+  # Web-related libraries
+  - beautifulsoup4
+  - lxml
+  - requests
+
+  # Spatial libraries
+  - astropy
   - cartopy
-  - cattrs
   - cfgrib
-  - cfchecker
-  - ciso8601
-  - click
-  - codespell
-  - colormaps
   - contextily
-  - dask
-  - dask-cloudprovider
-  - dask-gateway
+  - dask[complete]
   - dask-geopandas
   - dask-image
-  - dask-ml
+  - dask-jobqueue
   - datacube
-  - datashader
-  - defusedxml
-  - descartes
   - distributed
   - earthengine-api
   - eccodes>=2.24.2
-  - eodatasets3
+  - esda
   - fiona
-  - flake8
-  - folium
-  - fsspec
-  - gcsfs
   - geodatasets
   - geojson
   - geopandas>=0.11.0
-  - geoviews-core
-  - google-cloud-storage
-  - h3
+  - h3-py
+  - h3pandas
   - h5netcdf
   - h5py
-  - h5py
-  - holoviews
-  - hvplot
-  - intake
+  - imbalanced-learn
   - intake-esm
   - intake-geopandas
   - intake-stac
   - intake-xarray
-  - ipympl
-  - isort
-  - jsonschema
-  - jupyter-ui-poll
+  - libpysal
   - lmdb
-  - lxml
   - mapclassify
-  - matplotlib-base
-  - mypy
-  - nb_black
+  - mercantile
   - netcdf4
-  - numcodecs
-  - numexpr
-  - numpy
+  - odc-algo
   - odc-geo
   - odc-stac
-  - opencv
-  - pandas
-  - panel
-  - param
+  - openpyxl
   - pims
   - planetary-computer
   - pooch
-  - pre-commit
-  - pyam
   - pyarrow
-  - pydantic
+  - pyod
   - pyogrio
-  - pyrsistent
-  - pystac
-  - pytest
-  - pytest-cov
-  - python-dotenv
-  - python-graphviz
-  - python-rapidjson
-  - pyyaml
   - rasterio
+  - rio-cogeo
+  - rio-tiler
   - rioxarray
-  - s3fs
-  - scikit-image
-  - scikit-learn
-  - scipy
-  - seaborn
-  - slicerator
   - spatialpandas
-  - stac-geoparquet
   - stac-vrt
   - stackstac
   - stactools
-  - structlog
   - tabulate
   - tqdm
   - xarray
@@ -119,14 +181,33 @@ dependencies:
   - xvec
   - zarr
   - zstandard
+
+# other kind of libraries
+
+  - cfchecker
+  - colormaps
+  - defusedxml
+  - jupyter-ui-poll
+  - lmdb
+  - slicerator
+  - structlog
+  - python-rapidjson
+  - python-graphviz
+  - pyrsistent
+  - pyam
+  - eodatasets3
+
   - pip:
-      - stactools-geoparquet-items
-      - odc-ui
-      - odc-stac
-      - odc-stats
-      - odc-algo
-      - odc-io
-      - odc-cloud[ASYNC]
-      - mapbox # not sure if this is still being used
-      - mapboxcli # requires monkeypatch for Python 3.10
+      - antimeridian
+      - duckdb  # pypi has more recent releases
+      - movingpandas
+      - more-itertools
+      - networkx
+      - stac-geoparquet  # pypi has more recent releases
+      # - coclico  # probably better to install in dev mode (pip install -e .)
       - xstac
+    # Some useful odc libraries
+    # - dea-tools
+    # - odc-ui
+    # - odc-stats
+


### PR DESCRIPTION
@EtienneKras, what about restructuring the environment file a bit? So that it becomes easier to maintain. Also I think it's better if we pin the Python version instead of the wildcard
- restructure the environment file with categories for all the packages
- add some packages that are useful for working with stac
- pin the python version (3.12) instead of wildcarding it to higher than 3
